### PR TITLE
19 repository dispatch

### DIFF
--- a/.github/workflows/dispatch-receiver.yml
+++ b/.github/workflows/dispatch-receiver.yml
@@ -25,13 +25,14 @@ jobs:
       with:
         script: |
           const payload = context.payload.client_payload;
+          const targetRef = payload && payload.target_ref ? payload.target_ref : 'main';
           
           // Trigger the python-tests-allure-report workflow
           await github.rest.actions.createWorkflowDispatch({
             owner: context.repo.owner,
             repo: context.repo.repo,
             workflow_id: 'python-tests-allure-report.yml',
-            ref: context.ref,
+            ref: targetRef,
             inputs: {
               'source_repository': payload.repository || '',
               'source_ref': payload.ref || '',

--- a/.github/workflows/dispatch-receiver.yml
+++ b/.github/workflows/dispatch-receiver.yml
@@ -1,0 +1,69 @@
+name: Dispatch Receiver - Integration Test Trigger
+
+on:
+  # Listen for repository dispatch events from other repositories
+  repository_dispatch:
+    types: [integration-test-trigger]
+
+jobs:
+  trigger-integration-tests:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Log dispatch event details
+      run: |
+        echo "Triggered by repository dispatch from: ${{ github.event.client_payload.repository }}"
+        echo "Source ref: ${{ github.event.client_payload.ref }}"
+        echo "Source SHA: ${{ github.event.client_payload.sha }}"
+        echo "Triggered by: ${{ github.event.client_payload.actor }}"
+        echo "Source workflow: ${{ github.event.client_payload.workflow }}"
+        echo "Source run ID: ${{ github.event.client_payload.run_id }}"
+        echo "Source run number: ${{ github.event.client_payload.run_number }}"
+    
+    - name: Trigger python-tests-allure-report workflow
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const payload = context.payload.client_payload;
+          
+          // Trigger the python-tests-allure-report workflow
+          await github.rest.actions.createWorkflowDispatch({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            workflow_id: 'python-tests-allure-report.yml',
+            ref: context.ref,
+            inputs: {
+              'source_repository': payload.repository || '',
+              'source_ref': payload.ref || '',
+              'source_sha': payload.sha || '',
+              'source_actor': payload.actor || '',
+              'source_workflow': payload.workflow || '',
+              'source_run_id': payload.run_id || '',
+              'source_run_number': payload.run_number || '',
+              'triggered_by': 'repository_dispatch'
+            }
+          });
+          
+          console.log('Successfully triggered python-tests-allure-report workflow');
+    
+    - name: Notify source repository of workflow trigger
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ secrets.DISPATCH_TOKEN }}
+        script: |
+          const payload = context.payload.client_payload;
+          
+          // Post a status check back to the source repository
+          if (payload && payload.repository && payload.sha) {
+            const [owner, repo] = payload.repository.split('/');
+            
+            await github.rest.repos.createCommitStatus({
+              owner: owner,
+              repo: repo,
+              sha: payload.sha,
+              state: 'pending',
+              context: 'Integration Tests (testviper)',
+              description: 'Integration tests workflow triggered',
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            });
+          }

--- a/.github/workflows/dispatch-receiver.yml
+++ b/.github/workflows/dispatch-receiver.yml
@@ -25,14 +25,13 @@ jobs:
       with:
         script: |
           const payload = context.payload.client_payload;
-          const targetRef = payload && payload.target_ref ? payload.target_ref : 'main';
           
           // Trigger the python-tests-allure-report workflow
           await github.rest.actions.createWorkflowDispatch({
             owner: context.repo.owner,
             repo: context.repo.repo,
             workflow_id: 'python-tests-allure-report.yml',
-            ref: targetRef,
+            ref: 'main',
             inputs: {
               'source_repository': payload.repository || '',
               'source_ref': payload.ref || '',

--- a/.github/workflows/python-tests-allure-report.yml
+++ b/.github/workflows/python-tests-allure-report.yml
@@ -3,7 +3,7 @@ name: Integration Tests with Allure Report
 
 on:
   push:
-    branches: ["**"]
+    branches: ["main"]
   workflow_dispatch:
     inputs:
       source_repository:

--- a/.github/workflows/python-tests-allure-report.yml
+++ b/.github/workflows/python-tests-allure-report.yml
@@ -3,13 +3,60 @@ name: Integration Tests with Allure Report
 
 on:
   push:
-    branches: ["main"]
+    branches: ["**"]
+  workflow_dispatch:
+    inputs:
+      source_repository:
+        description: 'Source repository that triggered the dispatch'
+        required: false
+        type: string
+      source_ref:
+        description: 'Source branch/ref that triggered the dispatch'
+        required: false
+        type: string
+      source_sha:
+        description: 'Source commit SHA that triggered the dispatch'
+        required: false
+        type: string
+      source_actor:
+        description: 'Source actor that triggered the dispatch'
+        required: false
+        type: string
+      source_workflow:
+        description: 'Source workflow that triggered the dispatch'
+        required: false
+        type: string
+      source_run_id:
+        description: 'Source run ID that triggered the dispatch'
+        required: false
+        type: string
+      source_run_number:
+        description: 'Source run number that triggered the dispatch'
+        required: false
+        type: string
+      triggered_by:
+        description: 'How this workflow was triggered'
+        required: false
+        type: string
 
 jobs:
   integration-tests:
     runs-on: ubuntu-latest
     
     steps:
+    - name: Log dispatch information
+      if: github.event_name == 'workflow_dispatch'
+      run: |
+        echo "Workflow triggered by repository dispatch"
+        echo "Source repository: ${{ github.event.inputs.source_repository }}"
+        echo "Source ref: ${{ github.event.inputs.source_ref }}"
+        echo "Source SHA: ${{ github.event.inputs.source_sha }}"
+        echo "Source actor: ${{ github.event.inputs.source_actor }}"
+        echo "Source workflow: ${{ github.event.inputs.source_workflow }}"
+        echo "Source run ID: ${{ github.event.inputs.source_run_id }}"
+        echo "Source run number: ${{ github.event.inputs.source_run_number }}"
+        echo "Triggered by: ${{ github.event.inputs.triggered_by }}"
+    
     - name: Checkout repository
       uses: actions/checkout@v4
       


### PR DESCRIPTION
Need to merge the dispatch-receiver workflow to be able to test the dispatch sender from toolviper. This PR adds a new workflow that should receive a dispatch signal from toolviper and then trigger the Allure Reports workflow.